### PR TITLE
Admin password reset endpoint

### DIFF
--- a/backend/customuser/tests/test_password_reset.py
+++ b/backend/customuser/tests/test_password_reset.py
@@ -9,6 +9,9 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.contrib.auth.hashers import check_password, make_password
 from django.contrib.auth import get_user_model  # Get your User model
 
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken  # If using JWT
+
 
 from customuser.models import PasswordHistory
 
@@ -26,12 +29,12 @@ def test_password_reset_request(authenticated_client, user):
 
 
 @pytest.mark.django_db
-def test_password_reset_confirm(authenticated_client, user): # Use client, not authenticated_client for password reset
+def test_password_reset_confirm(client, user):
     """Test password reset confirmation and prevent reusing recent passwords"""
 
     old_passwords = ["OldPassword1!", "OldPassword2!", "OldPassword3!", "OldPassword4!", "OldPassword5!"]
     for old_password in old_passwords:
-        user.set_password(old_password)
+        user.set_password(old_password) 
         user.save()
         PasswordHistory.objects.create(user=user, password_hash=user.password)
 
@@ -40,25 +43,51 @@ def test_password_reset_confirm(authenticated_client, user): # Use client, not a
     url = reverse('customuser:password_reset_confirm', kwargs={'uidb64': uidb64, 'token': token})
 
     reuse_password = old_passwords[-1]
-    response = authenticated_client.post(url, {
+    response = client.post(url, {
         'new_password': reuse_password,
         'confirm_password': reuse_password
     }, format='json')
 
-    assert response.status_code == 400
-    assert "Cannot reuse a recent password." in str(response.data['error'])
+    assert response.status_code == status.HTTP_400_BAD_REQUEST  # Expect 400 (Bad Request)
+    assert "Cannot reuse a recent password." in str(response.data.get('error', ''))  # Check for error message
 
     new_password = "NewSecurePass456!"
-    response = authenticated_client.post(url, {
+    response = client.post(url, {
         'new_password': new_password,
         'confirm_password': new_password
     }, format='json')
 
     user.refresh_from_db()  
 
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.data['message'] == "Password has been reset successfully"
     assert check_password(new_password, user.password)
     assert PasswordHistory.objects.filter(user=user, password_hash=user.password).exists()
-    assert PasswordHistory.objects.count() == 6
+    assert PasswordHistory.objects.count() == len(old_passwords) + 1 
 
+
+@pytest.mark.django_db
+class TestAdminPasswordReset:
+    def test_admin_initiate_password_reset_success(self, authenticated_admin_client, user, mocker):
+        """Test successful admin-initiated password reset."""
+        url = reverse('customuser:admin_reset_password')
+        email = user.email
+
+        mock_send_mail = mocker.patch('customuser.utils.send_mail')
+
+        response = authenticated_admin_client.post(url, {'email': email}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['message'] == "Password reset link sent to user."
+
+    def test_admin_initiate_password_reset_invalid_email(self, authenticated_admin_client, mocker):
+        url = reverse('customuser:admin_reset_password')
+        email = "invalid-email"
+
+        mock_send_mail = mocker.patch('customuser.utils.send_mail')
+
+        response = authenticated_admin_client.post(url, {'email': email}, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST  
+        assert "Enter a valid email address." in str(response.data.get('email', ''))  
+        mock_send_mail.assert_not_called()

--- a/backend/customuser/urls.py
+++ b/backend/customuser/urls.py
@@ -21,6 +21,8 @@ urlpatterns = [
     path('token/refresh/', TokenRefreshView.as_view(), name='refresh-token'),
     path('password-reset/request/', PasswordResetRequestView.as_view(), name='password_reset_request'),
     path('password-reset/confirm/<uidb64>/<token>/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    path('users/admin-reset-password/', AdminInitiatePasswordResetView.as_view(), name='admin_reset_password'), # Correct URL
+
 
     path('', include(router.urls)),
 ]

--- a/backend/customuser/utils.py
+++ b/backend/customuser/utils.py
@@ -1,0 +1,41 @@
+from django.contrib.auth.hashers import check_password
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.conf import settings
+from django.core.mail import send_mail
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.urls import reverse
+
+from .models import PasswordHistory
+
+
+def check_recent_passwords(user, new_password):
+    """Checks if the new password is the same as any of the last 5 passwords."""
+    recent_passwords = PasswordHistory.objects.filter(user=user)[:5]
+    for past_password in recent_passwords:
+        if check_password(new_password, past_password.password_hash):
+            return True 
+    return False 
+
+
+def send_password_reset_email(request, user, subject_prefix="Password Reset Request"):
+    """
+    Sends an email to the user with a link to reset their password."""
+    token = PasswordResetTokenGenerator().make_token(user)
+    uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+    password_reset_confirm_url = reverse(
+        'customuser:password_reset_confirm',
+        kwargs={'uidb64': uidb64, 'token': token}
+    )
+    full_url = request.build_absolute_uri(password_reset_confirm_url)
+
+    message = f"Click the link below to reset your password:\n{full_url}\n\nThis link will expire in 10 minutes. If you do not reset your password within this time, you will need to request a new password reset."
+
+    send_mail(
+        subject=f"{subject_prefix}",  
+        message=message,
+        from_email=settings.EMAIL_HOST_USER,
+        recipient_list=[user.email],
+        fail_silently=True,
+    )
+  


### PR DESCRIPTION
This PR adds a new API endpoint at `/users/admin-password-reset/` to allow administrators to reset user passwords. Key features include:

*   **Admin-Only Access:**  Restricted to users with admin privileges.
*   **Email Validation:** Validates the provided email address before proceeding.
*   **User Existence Check:** Ensures the user with the given email exists.
*   **Standard Email Flow:** Triggers the existing password reset email flow.

* Admin sends password reset email
![image](https://github.com/user-attachments/assets/3190e74d-112c-4ee5-bdfc-3cdcd25ee54f)

* Email from Admin
![image](https://github.com/user-attachments/assets/15fa6187-786f-4524-aab6-79bc741b5660)

* Redirected to standard password reset view
![image](https://github.com/user-attachments/assets/f63ec70d-83cf-4c40-b6f5-502301a24958)
